### PR TITLE
Create dependency between kernel build/XML package

### DIFF
--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -41,7 +41,9 @@ endif
 LINUX_PATCHES = $(call qstrip,$(BR2_LINUX_KERNEL_PATCH))
 
 LINUX_INSTALL_IMAGES = YES
-LINUX_DEPENDENCIES += host-kmod host-lzop
+
+PLAT_XML_PACKAGE = $(patsubst "%",%, $(BR2_OPENPOWER_CONFIG_NAME))-xml
+LINUX_DEPENDENCIES += host-kmod host-lzop $(PLAT_XML_PACKAGE)
 
 ifeq ($(BR2_LINUX_KERNEL_UBOOT_IMAGE),y)
 	LINUX_DEPENDENCIES += host-uboot-tools


### PR DESCRIPTION
Sets up dependency between compiling the kernel + XML package for given platform (so that initramfs can be populated with XML package's bios metadata).
