### PR TITLE
Fix petitboot dependencies for ppc64le (include pciutils and iprutils)

### DIFF
--- a/package/petitboot/Config.in
+++ b/package/petitboot/Config.in
@@ -9,9 +9,9 @@ config BR2_PACKAGE_PETITBOOT
 	# run-time dependency only
 	select BR2_PACKAGE_KEXEC_LITE if !BR2_PACKAGE_KEXEC
 	# run-time dependency only
-	select BR2_PACKAGE_POWERPC_UTILS if BR2_powerpc || BR2_powerpc64
+	select BR2_PACKAGE_POWERPC_UTILS if BR2_powerpc || BR2_powerpc64 || BR2_powerpc64le
 	# run-time dependency only
-	select BR2_PACKAGE_IPRUTILS if BR2_powerpc || BR2_powerpc64
+	select BR2_PACKAGE_IPRUTILS if BR2_powerpc || BR2_powerpc64 || BR2_powerpc64le
 	help
 	  Petitboot is a small kexec-based bootloader
 


### PR DESCRIPTION
Otherwise on a ppc64le build rather than BE, we end up with a few
missing files in /usr/sbin/.

Proposed-fix-by: Patrick Williams III <iawillia@us.ibm.com>
Reported-by:  Pamela Eggler <eggler@us.ibm.com>
Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>