### PR TITLE
Update kexec-lite to latest version

### DIFF
--- a/package/kexec-lite/kexec-lite.mk
+++ b/package/kexec-lite/kexec-lite.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KEXEC_LITE_VERSION = fb8543fea3beb0522b5a63a74ea1a845dbd7b954
+KEXEC_LITE_VERSION = 783fb4a811d0b0f8cc2ed68fa7872dcad56a3944
 KEXEC_LITE_SITE = $(call github,antonblanchard,kexec-lite,$(KEXEC_LITE_VERSION))
 KEXEC_LITE_LICENSE = GPLv2+
 KEXEC_LITE_DEPENDENCIES = elfutils dtc


### PR DESCRIPTION
Pull in updates to kexec-lite, most notably:

4657d61 Fix crash due to processing "memory-controller" nodes as "memory"
150b14e trampoline: Reset primary cpu endian to big-endian
e226866 trampoline: Correctly set boot CPU on little-endian
