### PR TITLE
dropbear: Prevent install of init script

### DIFF
--- a/package/dropbear/dropbear.mk
+++ b/package/dropbear/dropbear.mk
@@ -59,12 +59,7 @@ define DROPBEAR_INSTALL_INIT_SYSTEMD
 		$(TARGET_DIR)/etc/systemd/system/multi-user.target.wants/dropbear.service
 endef
 
-ifeq ($(BR2_USE_MMU),y)
-define DROPBEAR_INSTALL_INIT_SYSV
-	$(INSTALL) -D -m 755 package/dropbear/S50dropbear \
-		$(TARGET_DIR)/etc/init.d/S50dropbear
-endef
-else
+ifneq ($(BR2_USE_MMU),y)
 DROPBEAR_POST_EXTRACT_HOOKS += DROPBEAR_DISABLE_STANDALONE
 endif
 


### PR DESCRIPTION
In the buildroot update we lost Jeremy's patch which prevents the dropbear server from starting on boot. There's since been some updates to the dropbear package so for the meantime just remove the install rule for the init script.