### PR TITLE
Restrict tar transform to regular files

### DIFF
--- a/support/download/git
+++ b/support/download/git
@@ -190,7 +190,7 @@ LC_ALL=C sort <"${output}.list" >"${output}.list.sorted"
 
 # Create GNU-format tarballs, since that's the format of the tarballs on
 # sources.buildroot.org and used in the *.hash files
-tar cf - --transform="s#^\./#${basename}/#" \
+tar cf - --transform="flags=r;s#^\./#${basename}/#" \
          --numeric-owner --owner=0 --group=0 --mtime="${date}" --format=gnu \
          -T "${output}.list.sorted" >"${output}.tar"
 gzip -6 -n <"${output}.tar" >"${output}"


### PR DESCRIPTION
Without this restriction, symlinks are rewritten and corrupted.

Example without the restriction:

Input tree (valid):
package-githash/file1
package-githash/link -> ./file1

Output tree (broken):
package-githash/file1
package-githash/link -> package-githash/file1