### PR TITLE
Fix PnorUtils.pm Creates Unnecessary File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.rej
 *~
 *.pyc
+*WithOffsets.xml


### PR DESCRIPTION
OP Build's Hostboot PnorUtils.pm creates file
ending with *WithOffsets.xml. Placing this file
name under gitignore.

Signed-off-by: Luis Fernandez <Luis.Fernandez@ibm.com>